### PR TITLE
Update tooltip fragment shader

### DIFF
--- a/resources/assets/minecraft/shaders/core/position_color.fsh
+++ b/resources/assets/minecraft/shaders/core/position_color.fsh
@@ -9,19 +9,20 @@ in vec4 Coords;
 in vec2 position;
 
 uniform vec4 ColorModulator;
+uniform mat4 ProjMat;
 
 out vec4 fragColor;
 
 vec4 colors[9] = vec4[](
     vec4(0),
-    vec4(50, 50, 50, 255) / 255,
-    vec4(235, 235, 235, 235) / 255,
-    vec4(41, 56, 64, 222) / 255,
-    vec4(37, 49, 58, 210) / 255,
-    vec4(35, 49, 55, 234) / 255,
-    vec4(37, 51, 58, 230) / 255,
-    vec4(43, 57, 66, 217) / 255,
-    vec4(46, 63, 71, 210) / 255
+    vec4(50, 50, 50, 255) / 255,    //#323232
+    vec4(235, 235, 235, 235) / 255, //#EBEBEB
+    vec4(41, 56, 64, 222) / 255,    //#2A3840
+    vec4(37, 49, 58, 210) / 255,    //#25313A
+    vec4(35, 49, 55, 234) / 255,    //#233137
+    vec4(37, 51, 58, 230) / 255,    //#25333A
+    vec4(43, 57, 66, 217) / 255,    //#2B3942
+    vec4(46, 63, 71, 210) / 255     //#2E3F47
 );
 
 int bitmap[64] = int[](
@@ -39,12 +40,20 @@ int bitmap[64] = int[](
 
 void main() {
     vec4 color = vertexColor;
+
     if (color.a == 0.0) {
         discard;
     }
 
     fragColor = color * ColorModulator;
 
+
+    // Removes shadow in GUIs' & Menus
+    if (ProjMat[3][2] == -2.0 && color.g*255.0 == 16.0 && color.b*255.0 == 16.0 && color.r*255.0 == 16.0){
+        discard;
+    }
+
+    // Fancy math stuff to find the tooltip from the vertex shader
     if (flatCorner != vec2(-1))
     {
         //Actual Pos
@@ -62,31 +71,43 @@ void main() {
 
         ivec2 corner = min(pos, res - pos);
 
-        if (corner.x < 8 && corner.y < 8)
+        // Remove tooltip if too large (used for menus)
+        if (res.x > 1000)
         {
-            int bit = bitmap[corner.y * 8 + corner.x];
-            if (bit == 0)
-                discard;
-            if (bit != 9)
-                col = colors[bit];
+            discard;
         }
-        else if (corner.x == 0 || corner.x == 1)
-            col = colors[2];
-        else if (corner.x == 2)
-            col = colors[1];
-        else if (corner.x == 3)
-            col = colors[7];
-        else if (corner.x == 4)
-            col = colors[8];
-        else if (corner.y == 0 || corner.y == 1)
-            col = colors[2];
-        else if (corner.y == 2)
-            col = colors[1];
-        else if (corner.y == 3)
-            col = colors[7];
-        else if (corner.y == 4)
-            col = colors[8];
+        else // If the tooltip isnt too large, continue as normal.
+        {
+            if (corner.x < 8 && corner.y < 8)
+            {
+                int bit = bitmap[corner.y * 8 + corner.x]; 
+                // due to glsl restrictions the *8  exists so the bitmap can be 2d. Why a 2d bitmap? no idea.
+                if (bit == 0)
+                    discard;
+                if (bit != 9)
+                    col = colors[bit];
+            }
+            // For the rest of the image find its location, and render the approptriate colour
+            else if (corner.x == 0 || corner.x == 1)
+                col = colors[2];
+            else if (corner.x == 2)
+                col = colors[1];
+            else if (corner.x == 3)
+                col = colors[7];
+            else if (corner.x == 4)
+                col = colors[8];
+            else if (corner.y == 0 || corner.y == 1)
+                col = colors[2];
+            else if (corner.y == 2)
+                col = colors[1];
+            else if (corner.y == 3)
+                col = colors[7];
+            else if (corner.y == 4)
+                col = colors[8];
+        }
 
+
+        // Final output of colours
         fragColor = col;
         
     }


### PR DESCRIPTION
Updates the fragment shader for future menu development.
* Adds ability to remove tooltip
* Removes GUI/Menu Background shadow

Note:
1.19.4 will break tooltip rendering, and I am unsure how to fix it.
![2023-02-25_15 57 23](https://user-images.githubusercontent.com/49575478/221385111-71609782-e3e1-4b74-b7fe-0e2ccdc8ada4.png)
![2023-02-25_15 57 28](https://user-images.githubusercontent.com/49575478/221385114-ec069289-5929-442e-91d0-08bbff609a68.png)
